### PR TITLE
Fix netCDF-loaded conversions: drop dispatch set-points, scale the investment cap

### DIFF
--- a/pypsa2smspp/__init__.py
+++ b/pypsa2smspp/__init__.py
@@ -34,6 +34,7 @@ from pypsa2smspp.transformation_config import TransformationConfig
 from pypsa2smspp.network_correction import (
     clean_marginal_cost,
     clean_global_constraints,
+    clean_dispatch_setpoints,
     clean_e_sum,
     clean_efficiency_link,
     clean_ciclicity_storage,
@@ -51,6 +52,7 @@ __all__ = [
     # network correction tools
     "clean_marginal_cost",
     "clean_global_constraints",
+    "clean_dispatch_setpoints",
     "clean_e_sum",
     "clean_efficiency_link",
     "clean_ciclicity_storage",

--- a/pypsa2smspp/network_correction.py
+++ b/pypsa2smspp/network_correction.py
@@ -32,7 +32,40 @@ def clean_global_constraints(n, inplace=True):
         net.remove("GlobalConstraint", net.global_constraints.index)
 
     return net
-    
+
+def clean_dispatch_setpoints(n, inplace=True):
+    """
+    Drop the dispatch set-points (p_set, e_set) of dispatchable components.
+
+    On Generator/Link/Store/StorageUnit a finite p_set (or e_set) is a
+    power-flow set-point, not a LOPF input; recent PyPSA enforces it as a
+    fixed-dispatch equality constraint, which freezes those components (e.g. a
+    p_set=0 on a heat-supply link forces the optimizer to shed the heat demand
+    at VOLL instead of serving it). SMS++ ignores these set-points, so leaving
+    them in only inflates the PyPSA reference. Load p_set is the demand and is
+    kept. Networks built from Excel already drop it in add_component; this
+    covers networks loaded from netCDF or built outside that path.
+    """
+    net = n if inplace else n.copy()
+
+    # component (plural table) -> its dispatch set-point attributes
+    dispatchable = {
+        "generators": ("p_set",),
+        "links": ("p_set",),
+        "stores": ("p_set", "e_set"),
+        "storage_units": ("p_set",),
+    }
+    for plural, attrs in dispatchable.items():
+        static = getattr(net, plural)
+        dynamic = getattr(net, plural + "_t")
+        for attr in attrs:
+            if attr in static.columns:
+                static[attr] = np.nan
+            if attr in dynamic and not dynamic[attr].empty:
+                dynamic[attr] = dynamic[attr].iloc[:, :0]
+
+    return net
+
 def clean_e_sum(n):
     n.generators.e_sum_max = float('inf')
     n.generators_e_sum_min = float('-inf')

--- a/pypsa2smspp/transformation.py
+++ b/pypsa2smspp/transformation.py
@@ -12,7 +12,6 @@ import os
 from pypsa2smspp.transformation_config import TransformationConfig
 from pysmspp import SMSNetwork, SMSFileType, Attribute, Dimension, Variable, Block, SMSConfig
 from pypsa2smspp import logger
-from copy import deepcopy
 import pysmspp
 from pathlib import Path
 from typing import Any, Dict, Mapping, Optional, Sequence, Union, Literal, Callable
@@ -233,8 +232,11 @@ class Transformation:
 
             Any other keys are forwarded as solver-constructor kwargs (power-user usage).
         """
-        config = TransformationConfig()
-        self.config = deepcopy(config)
+        # NB: assign a fresh config directly (do NOT deepcopy). The parameter
+        # lambdas capture `self` in their closure; a deepcopy leaves them bound
+        # to the original instance, so later overrides of e.g.
+        # config.investment_upper_bound would be silently ignored.
+        self.config = TransformationConfig()
 
         self.merge_links = merge_links
         if merge_selector is not None:
@@ -295,7 +297,9 @@ class Transformation:
         n.stores['max_hours'] = self.config.max_hours_stores
         n.storage_units['snapshots_weighting'] = n.snapshot_weightings['stores'].iloc[0]
         n.stores['snapshots_weighting'] = n.snapshot_weightings['stores'].iloc[0]
-        
+
+        self._set_investment_upper_bound(n)
+
         n_direct = get_base_scenario_network(n)
 
         with step(self.timer, "consistency_check", verbose=verbose):
@@ -309,9 +313,40 @@ class Transformation:
 
         with step(self.timer, "convert_to_blocks", verbose=verbose):
             self.sms_network = self.convert_to_blocks()
-        
+
         return self.sms_network
-    
+
+    def _set_investment_upper_bound(self, n):
+        """
+        Set a proportional, non-binding investment cap for uncapped assets.
+
+        A finite value is substituted for a non-finite ``p_nom_max`` when building
+        the InvestmentBlock UpperBound. A fixed huge cap (e.g. 1e13) never binds
+        but is badly scaled: it makes CPLEX/HiGHS abort and floors the Lagrangian
+        bundle's convergence through a badly-conditioned master QP. Scaling the
+        cap to the peak total demand keeps it non-binding (no single asset
+        usefully exceeds the total demand it can serve, over any horizon) while
+        keeping the numerics well conditioned. Falls back to the configured
+        ``investment_upper_bound`` when there is no demand to scale against.
+        """
+        # Scale = total weighted energy demand (MWh): it upper-bounds both the
+        # power capacity of any generator/link and the ENERGY capacity of any
+        # store (whose e_nom, power x hours, can be far larger than the peak
+        # power), so the cap never truncates either. The peak power is kept as a
+        # floor for the degenerate single-snapshot case.
+        scale = 0.0
+        p_set = n.loads_t.get("p_set")
+        if p_set is not None and not p_set.empty:
+            total = p_set.abs().sum(axis=1)
+            w = n.snapshot_weightings["objective"]
+            scale = max(float((total * w).sum()), float(total.max()))
+        if "p_set" in n.loads.columns:
+            scale = max(scale, float(n.loads["p_set"].abs().fillna(0.0).sum()))
+        if scale > 0.0:
+            self.config.investment_upper_bound = (
+                self.config.investment_upper_bound_factor * scale
+            )
+
     def optimize(self, verbose: bool = True):
         if self.sms_network is None:
             raise ValueError("Model must be created before optimization. Call create_model(n) first.")

--- a/pypsa2smspp/transformation_config.py
+++ b/pypsa2smspp/transformation_config.py
@@ -229,9 +229,15 @@ class TransformationConfig:
         self.max_hours_stores = 1
 
         # Cap substituted for a non-finite p_nom_max when building the
-        # InvestmentBlock UpperBound. np.inf leaves the asset uncapped
-        # (InvestmentBlock treats a non-finite UpperBound as no upper bound);
-        # a finite value caps it. A too-small finite cap silently truncates
-        # the optimum (e.g. a store whose true optimum exceeds the cap).
+        # InvestmentBlock UpperBound. It must not bind (else it truncates the
+        # optimum) yet stay well scaled: a huge fixed cap like 1e13 wrecks the
+        # numerics (CPLEX/HiGHS abort, and it floors the Lagrangian bundle's
+        # convergence via a badly-scaled master QP). Transformation.create_model
+        # therefore overrides this with investment_upper_bound_factor times the total
+        # energy demand (see there); this default is only a fallback for
+        # networks with no demand to scale against.
         self.investment_upper_bound = 1e13
+        # Multiple of the total energy demand used as the (proportional,
+        # well-scaled) non-binding investment cap.
+        self.investment_upper_bound_factor = 1e1
 

--- a/test/main_pypsaeur.py
+++ b/test/main_pypsaeur.py
@@ -74,6 +74,7 @@ PYSMSSP_OPTIONS = {"logging": True}
 # Cleaning toggles
 DO_CLEAN_E_SUM = False
 DO_CLEAN_CICLICITY_STORAGE = False
+DO_CLEAN_DISPATCH_SETPOINTS = True  # drop p_set/e_set on dispatchable comps
 DO_ADD_SLACK_UNIT = True
 DO_REDUCE_SNAPSHOTS = True
 REDUCE_SNAPSHOTS_TO = 200
@@ -116,6 +117,7 @@ from pypsa2smspp.transformation import Transformation
 from pypsa2smspp.network_correction import (
     clean_e_sum,
     clean_ciclicity_storage,
+    clean_dispatch_setpoints,
     add_slack_unit,
     reduce_snapshots_and_scale_costs,
     clean_storage_units,
@@ -237,6 +239,9 @@ try:
 
     if DO_CLEAN_CICLICITY_STORAGE:
         n_smspp = clean_ciclicity_storage(n_smspp)
+
+    if DO_CLEAN_DISPATCH_SETPOINTS:
+        n_smspp = clean_dispatch_setpoints(n_smspp)
 
     if DO_REDUCE_SNAPSHOTS:
         n_smspp = reduce_snapshots_and_scale_costs(n_smspp, target=REDUCE_SNAPSHOTS_TO, scale_capital_costs=False)

--- a/test/test_mainpypsaeur.py
+++ b/test/test_mainpypsaeur.py
@@ -42,7 +42,10 @@ OUT_TEST.mkdir(parents=True, exist_ok=True)
 
 # --- Domain imports (after PYTHONPATH is set) ---
 from pypsa2smspp.transformation import Transformation
-from pypsa2smspp.network_correction import clean_ciclicity_storage
+from pypsa2smspp.network_correction import (
+    clean_ciclicity_storage,
+    clean_dispatch_setpoints,
+)
 
 
 # ---------- Utilities ----------
@@ -72,6 +75,7 @@ def run_single_nc(
     capacity_expansion_ucblock: bool,
     solver_name: str = "gurobi",
     do_clean_ciclicity_storage: bool = True,
+    do_clean_dispatch_setpoints: bool = True,
     export_pypsa_lp: bool = True,
     export_pypsa_nc: bool = True,
     export_smspp_repopulated_nc: bool = True,
@@ -116,6 +120,8 @@ def run_single_nc(
         n_clean = n_raw
         if do_clean_ciclicity_storage:
             n_clean = clean_ciclicity_storage(n_clean)
+        if do_clean_dispatch_setpoints:
+            n_clean = clean_dispatch_setpoints(n_clean)
 
         # -------- PyPSA optimization (reference) --------
         network = n_clean.copy()


### PR DESCRIPTION
Two fixes to the netCDF-loaded conversion path:

- **Drop dispatch set-points** (`clean_dispatch_setpoints`): strip `p_set`/`e_set` on generators/links/stores/storage_units (kept on loads). Recent PyPSA enforces a finite `p_set` as fixed dispatch, which froze heat-supply links and inflated the reference objective. The Excel path already dropped it in `add_component`; this covers netCDF.
- **Scale the investment cap to demand** instead of a fixed 1e13: the huge cap never bound but wrecked the numerics (CPLEX/HiGHS aborted, and it floored the Lagrangian bundle's convergence via a badly-scaled master QP). Now `investment_upper_bound_factor` × total energy demand, set in `create_model`; the config is assigned directly (not deep-copied) so the parameter-lambda closures see runtime overrides.

Verified: `test_investmentblock` 8 passed / 7 skipped; sector-coupled reference == SMS++.